### PR TITLE
Adding tfidf tentative code

### DIFF
--- a/LDA.py
+++ b/LDA.py
@@ -1,0 +1,109 @@
+from nltk.tokenize import word_tokenize
+from gensim import corpora
+import gensim
+
+# Your data
+titles = []
+reviews = []
+title_to_tag = {}
+
+# Read reviews and titles from file
+with open("LDA_test_texts/reviews_test.txt", "r") as file:
+    lines = file.readlines()
+    for line in lines:
+        split_line = line.split("):")
+        if len(split_line) > 1:
+            title = split_line[0].strip()
+            review = ":".join(split_line[1:]).strip()
+            titles.append(title)
+            reviews.append(review)
+
+# Read tags from file and map titles to tags
+with open("LDA_test_texts/oscar_status.txt", "r") as file:
+    lines = file.readlines()
+    for line in lines:
+        split_line = line.split("):")
+        if len(split_line) > 1:
+            title = split_line[0].strip()
+            tag = ":".join(split_line[1:]).strip()
+            title_to_tag[title] = tag
+
+# Create labels corresponding to reviews
+labels = [title_to_tag[title] for title in titles]
+
+# Tokenize the reviews
+tokenized_reviews = [word_tokenize(review.lower()) for review in reviews]
+
+# Create a dictionary and corpus
+dictionary = corpora.Dictionary(tokenized_reviews)
+corpus = [dictionary.doc2bow(review) for review in tokenized_reviews]
+
+# Build the LDA model
+lda_model = gensim.models.LdaModel(
+    corpus=corpus,
+    id2word=dictionary,
+    num_topics=10,  # Number of topics to extract (adjust as needed)
+    passes=15,  # Number of passes through the corpus during training
+    random_state=42,
+)
+
+# Adding each review's topic distribution to a list and adding the probabilities so each review has a probability
+topic_distributions = []
+for review in corpus:
+    topic_distribution = lda_model[review]
+    topic_distributions.append(topic_distribution)
+
+for i in range(len(topic_distributions)):
+    topic_distribution = topic_distributions[i]
+    total_probability = 0
+    for topic in topic_distribution:
+        total_probability += topic[1]
+    for j in range(len(topic_distribution)):
+        topic_distribution[j] = (
+            topic_distribution[j][0],
+            topic_distribution[j][1] / total_probability,
+        )
+    topic_distributions[i] = topic_distribution
+
+# Matching probabilities with winner, nominee, or no recognition tags
+topic_probabilities_with_tags = []
+for i in range(len(topic_distributions)):
+    topic_probabilities_with_tags.append((topic_distributions[i], labels[i]))
+
+print(topic_probabilities_with_tags)
+
+import pyLDAvis
+import pyLDAvis.gensim
+
+vis = pyLDAvis.gensim.prepare(
+    topic_model=lda_model, corpus=corpus, dictionary=dictionary
+)
+pyLDAvis.enable_notebook()
+pyLDAvis.display(vis)
+
+
+# Classiyfing new review based on topic probabilities with tags
+def classify_new_review(review: str) -> list[float]:
+    """Classify a new review based on topic probabilities with tags."""
+    # Tokenize the review
+    tokenized_review = word_tokenize(review.lower())
+
+    # Create a dictionary and corpus
+    dictionary = corpora.Dictionary([tokenized_review])
+    corpus = [dictionary.doc2bow(tokenized_review)]
+
+    # Extract the topic distribution for the new review
+    topic_distribution = lda_model[corpus[0]]
+
+    # Extract the probabilities for each topic for the new review
+    topic_probability = []
+    for topic in topic_probabilities_with_tags:
+        topic_probability.append(topic[1])
+
+    return topic_probability
+
+
+# Example usage:
+user_input = "This movie was to die for"
+topic_dist = classify_new_review(user_input)
+# print("Topic Distribution for the New Review:", topic_probabilities)

--- a/LDA_test_texts/oscar_status.txt
+++ b/LDA_test_texts/oscar_status.txt
@@ -1,0 +1,74 @@
+The Godfather (1972): Winner
+Pulp Fiction (1994): Winner
+Inception (2010): Winner
+The Shawshank Redemption (1994): Nominee
+The Dark Knight (2008): Winner
+Forrest Gump (1994): Winner
+Schindler's List (1993): Winner
+The Matrix (1999): Winner
+Fight Club (1999): Nominee
+The Silence of the Lambs (1991): Winner
+Eternal Sunshine of the Spotless Mind (2004): Winner
+Goodfellas (1990): Winner
+The Lord of the Rings: The Fellowship of the Ring (2001): Winner
+The Social Network (2010): Winner
+Whiplash (2014): Winner
+The Departed (2006): Winner 
+Gladiator (2000): Winner
+Interstellar (2014): Winner
+The Usual Suspects (1995): Winner
+The Prestige (2006): Nominee
+Blade Runner 2049 (2017): Winner
+Her (2013): Winner
+Arrival (2016): Winner
+No Country for Old Men (2007): Winner
+A Beautiful Mind (2001): Winner
+The Grand Budapest Hotel (2014): Winner
+La La Land (2016): Winner
+The Revenant (2015): Winner
+Mad Max: Fury Road (2015): Winner
+Birdman (2014): Winner
+The Shape of Water (2017): Winner
+Moonlight (2016): Winner
+The Truman Show (1998): Winner
+Gravity (2013): Winner
+The Big Lebowski (1998): No Recognition
+Black Swan (2010): Winner 
+The King's Speech (2010): Winner 
+Spotlight (2015): Winner 
+The Hurt Locker (2008): Winner
+American Beauty (1999): Winner
+Memento (2000): Nominee
+Manchester by the Sea (2016): Winner
+There Will Be Blood (2007): Winner
+Casino Royale (2006): No Recognition
+The Aviator (2004): Winner
+Dallas Buyers Club (2013): Winner
+Lost in Translation (2003): Winner
+The Artist (2011): Winner
+Boyhood (2014): Winner
+Roma (2018): Winner 
+The Room (2003): No Recognition
+Troll 2 (1990): No Recognition
+Birdemic: Shock and Terror (2010): No Recognition
+Plan 9 from Outer Space (1959): No Recognition
+Manos: The Hands of Fate (1966): No Recognition
+Gigli (2003): No Recognition
+Catwoman (2004): No Recognition
+The Love Guru (2008): No Recognition
+Batman & Robin (1997): No Recognition
+Jack and Jill (2011): No Recognition
+The Hottie & the Nottie (2008): No Recognition
+After Last Season (2009): No Recognition
+Disaster Movie (2008): No Recognition
+The Emoji Movie (2017): No Recognition
+Battlefield Earth (2000): No Recognition
+Alone in the Dark (2005): No Recognition
+Swept Away (2002): No Recognition
+The Master of Disguise (2002): No Recognition
+The Wicker Man (2006): No Recognition
+Cats (2019): No Recognition
+The Adventures of Pluto Nash (2002): No Recognition
+A Sound of Thunder (2005): No Recognition
+Superbabies: Baby Geniuses 2 (2004): No Recognition
+Ballistic: Ecks vs. Sever (2002): No Recognition

--- a/LDA_test_texts/reviews_test.txt
+++ b/LDA_test_texts/reviews_test.txt
@@ -1,0 +1,74 @@
+The Godfather (1972): A timeless masterpiece, showcasing the intricacies of power and family.
+Pulp Fiction (1994): A non-linear narrative with quirky characters and unforgettable dialogue.
+Inception (2010): Mind-bending and visually stunning, exploring dreams within dreams.
+The Shawshank Redemption (1994): A poignant tale of hope and friendship against the backdrop of prison life.
+The Dark Knight (2008): A gritty, intense superhero film anchored by Heath Ledger's iconic Joker.
+Forrest Gump (1994): Heartwarming and profound, tracing one man's journey through American history.
+Schindler's List (1993): A haunting portrayal of the Holocaust and one man's acts of humanity.
+The Matrix (1999): Groundbreaking in its concept, blending philosophy with action-packed sequences.
+Fight Club (1999): A dark, psychological exploration of masculinity and consumer culture.
+The Silence of the Lambs (1991): Gripping and chilling, with stellar performances from Jodie Foster and Anthony Hopkins.
+Eternal Sunshine of the Spotless Mind (2004): A beautiful and unconventional love story with a sci-fi twist.
+Goodfellas (1990): Raw and unapologetic, a portrayal of the mob world with captivating storytelling.
+The Lord of the Rings: The Fellowship of the Ring (2001): Epic fantasy that sets the stage for an incredible journey.
+The Social Network (2010): A gripping account of the founding of Facebook and its creator's complexities.
+Whiplash (2014): Intense and exhilarating, exploring the sacrifices in the pursuit of greatness.
+The Departed (2006): A gripping crime thriller with stellar performances and unexpected twists.
+Gladiator (2000): A grand spectacle of action and revenge set in ancient Rome.
+Interstellar (2014): Ambitious and visually stunning, exploring themes of love and time.
+The Usual Suspects (1995): A twisty, suspenseful crime drama with an unforgettable ending.
+The Prestige (2006): A mesmerizing tale of rival magicians with a narrative full of surprises.
+Blade Runner 2049 (2017): A visually breathtaking sci-fi sequel that pays homage to the original.
+Her (2013): A poignant and thought-provoking love story between a man and an AI.
+Arrival (2016): Intelligent and emotionally resonant, exploring communication and time.
+No Country for Old Men (2007): Gritty and intense, a masterclass in tension and suspense.
+A Beautiful Mind (2001): A powerful portrayal of the life of mathematician John Nash.
+The Grand Budapest Hotel (2014): Quirky and visually delightful, a Wes Anderson gem.
+La La Land (2016): A modern musical with stunning visuals and a bittersweet love story.
+The Revenant (2015): A visceral survival story with breathtaking cinematography.
+Mad Max: Fury Road (2015): Non-stop action and visual spectacle in a post-apocalyptic world.
+Birdman (2014): A unique and surreal look at fame and artistic ambition.
+The Shape of Water (2017): A visually stunning and unconventional love story.
+Moonlight (2016): A deeply affecting exploration of identity and coming-of-age.
+The Truman Show (1998): A thought-provoking satire on reality TV and individual freedom.
+Gravity (2013): A tense and visually immersive space survival story.
+The Big Lebowski (1998): A cult classic with quirky characters and absurd humor.
+Black Swan (2010): Dark and haunting, a psychological thriller centered on ballet.
+The King's Speech (2010): A touching historical drama about King George VI's speech impediment.
+Spotlight (2015): A powerful and meticulously crafted depiction of investigative journalism.
+The Hurt Locker (2008): A gripping portrayal of bomb disposal units in Iraq.
+American Beauty (1999): A darkly comedic take on suburban disillusionment.
+Memento (2000): A mind-bending thriller told in reverse, exploring memory and revenge.
+Manchester by the Sea (2016): A deeply emotional story of grief and redemption.
+There Will Be Blood (2007): A mesmerizing character study with an unforgettable lead performance.
+Casino Royale (2006): A gritty and rejuvenated take on James Bond.
+The Aviator (2004): A sweeping biopic of Howard Hughes with stellar performances.
+Dallas Buyers Club (2013): A powerful portrayal of the AIDS crisis with remarkable performances.
+Lost in Translation (2003): A quiet and introspective exploration of loneliness and connection.
+The Artist (2011): A charming and nostalgic ode to silent cinema.
+Boyhood (2014): A unique coming-of-age story filmed over 12 years.
+Roma (2018): A visually stunning and emotionally resonant portrayal of a domestic worker's life in Mexico City.
+The Room (2003): A perplexing yet strangely captivating melodrama that defies traditional filmmaking norms.
+Troll 2 (1990): A cult classic known for its unintentional humor and bizarre storyline.
+Birdemic: Shock and Terror (2010): An amateurish yet oddly entertaining thriller about a bird attack.
+Plan 9 from Outer Space (1959): A sci-fi film often regarded as one of the worst movies ever made, yet intriguing in its own way.
+Manos: The Hands of Fate (1966): A low-budget horror film with a surreal and unsettling atmosphere.
+Gigli (2003): A romantic comedy-drama that failed to resonate with audiences despite its star-studded cast.
+Catwoman (2004): A superhero film widely panned for its weak plot and lackluster execution.
+The Love Guru (2008): A comedy that struggled to find its footing, despite efforts from its lead actor.
+Batman & Robin (1997): A colorful but critically derided superhero film known for its campy style.
+Jack and Jill (2011): A comedy that received heavy criticism for its humor and execution.
+The Hottie & the Nottie (2008): A romantic comedy widely panned for its premise and execution.
+After Last Season (2009): A perplexing and poorly produced independent film that leaves viewers bewildered.
+Disaster Movie (2008): A comedy that attempted satire but fell short in its execution and humor.
+The Emoji Movie (2017): An animated film that faced criticism for its lackluster storyline and commercialism.
+Battlefield Earth (2000): A sci-fi film that struggled with both critical reception and box office success.
+Alone in the Dark (2005): A horror film adaptation that failed to capture the essence of its source material.
+Swept Away (2002): A romantic drama that failed to connect with audiences despite its premise.
+The Master of Disguise (2002): A comedy criticized for its humor and lack of substantial plot.
+The Wicker Man (2006): A remake that received negative reviews for its execution and departure from the original.
+Cats (2019): A musical adaptation widely criticized for its visual effects and narrative coherence.
+The Adventures of Pluto Nash (2002): A sci-fi comedy that fell flat in its attempts at humor and storytelling.
+A Sound of Thunder (2005): A sci-fi film that failed to impress with its special effects and storyline.
+Superbabies: Baby Geniuses 2 (2004): A family film that struggled to gain positive reception.
+Ballistic: Ecks vs. Sever (2002): An action film criticized for its convoluted plot and action sequences.

--- a/TFIDF.py
+++ b/TFIDF.py
@@ -1,0 +1,83 @@
+import nltk
+from nltk.tokenize import word_tokenize
+from sklearn.feature_extraction.text import TfidfVectorizer
+from sklearn.model_selection import train_test_split
+from sklearn.naive_bayes import MultinomialNB
+from sklearn.metrics import accuracy_score
+
+nltk.download("punkt")
+
+# Your data
+titles = []
+reviews = []
+title_to_tag = {}
+
+# Read reviews and titles from file
+with open("LDA_test_texts/reviews_test.txt", "r") as file:
+    lines = file.readlines()
+    for line in lines:
+        split_line = line.split("):")
+        if len(split_line) > 1:
+            title = split_line[0].strip()
+            review = ":".join(split_line[1:]).strip()
+            titles.append(title)
+            reviews.append(review)
+
+# Read tags from file and map titles to tags
+with open("LDA_test_texts/oscar_status.txt", "r") as file:
+    lines = file.readlines()
+    for line in lines:
+        split_line = line.split("):")
+        if len(split_line) > 1:
+            title = split_line[0].strip()
+            tag = ":".join(split_line[1:]).strip()
+            title_to_tag[title] = tag
+
+# Create labels corresponding to reviews
+labels = [title_to_tag[title] for title in titles]
+
+# Initialize the TF-IDF Vectorizer
+tfidf_vectorizer = TfidfVectorizer()
+
+# Transform the reviews into TF-IDF features
+X = tfidf_vectorizer.fit_transform(reviews)
+
+# Split the data into training and testing sets
+X_train, X_test, y_train, y_test = train_test_split(
+    X, labels, test_size=0.2, random_state=42
+)
+
+# Initialize and train a classifier (e.g., Naive Bayes)
+nb_classifier = MultinomialNB()
+nb_classifier.fit(X_train, y_train)
+
+# Predict on the test set
+predictions = nb_classifier.predict(X_test)
+
+# Calculate accuracy
+accuracy = accuracy_score(y_test, predictions)
+print("Accuracy:", accuracy)
+
+
+def classify_review(review):
+    # Vectorize the input review using the pre-trained TfidfVectorizer
+    review_vec = tfidf_vectorizer.transform([review])
+
+    # Predict the class of the input review using the trained classifier
+    prediction = nb_classifier.predict(review_vec)[0]
+
+    return prediction
+
+
+# Example usage:
+# user_review = input("Enter your review: ")
+user_review = "I loved this movie! The acting was great, plot was wonderful, and there were pyrotechnics!"
+classification = classify_review(user_review)
+
+# Map the prediction to the corresponding category (winner, nominee, or no recognition)
+if classification == "Winner":
+    print("This review is classified as a Winner!")
+elif classification == "Nominee":
+    print("This review is classified as a Nominee!")
+else:
+    print("This review has no recognition.")


### PR DESCRIPTION
Hello guys. I'm adding the test txt files (basically synthetic data we could even use later). There is one with movie titles and reviews, and the other with movie titles and their win, nominee or no recognition tags. 

I'm also adding a tfidf py file which is working pretty well to distinguish between winner and no recognition (but there's 0 accuracy for nominee as of now, which I am certain is because there are only a couple of reviews of nominated movies in my data). 

You guys were also correct about LDA. It is turning out to be much harder than I thought so I pivoted to tfidf for a bit and got it running just so that there is something out there. Still working on LDA on this branch and will push when I get it up and running. 